### PR TITLE
fix to expose L.CanvasIconLayer class

### DIFF
--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -594,6 +594,8 @@ function layerFactory(L) {
     L.canvasIconLayer = function (options) {
         return new CanvasIconLayer(options);
     };
+
+    return CanvasIconLayer;
 };
 
 module.exports = layerFactory;


### PR DESCRIPTION
This was originally meant but missed (see _full.js / _standalone.js)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spaction/leaflet.canvas-markers/4)
<!-- Reviewable:end -->
